### PR TITLE
Refactor Mordor Testnet configuration and update Ethereum Classic details

### DIFF
--- a/stablepay-sdk/src/utils/config.js
+++ b/stablepay-sdk/src/utils/config.js
@@ -63,7 +63,7 @@ export const networksConfig = {
     djedAddress: '0xCc3664d7021FD36B1Fe2b136e2324710c8442cCf', 
     tokens: {
       stablecoin: {
-        symbol: 'SC',
+        symbol: 'ECSD',
         address: '0x5A7Ca94F6E969C94bef4CE5e2f90ed9d4891918A',  
         decimals: 18,
         isDirectTransfer: true


### PR DESCRIPTION
Solves #18 

Changes:


Renamed Network: Updated the Ethereum Classic configuration key and display name to "mordor-testnet".


Added Network: Introduced a new configuration entry for Ethereum Classic with the following details:


Chain ID: 61


RPC: https://etc.rivet.link/


Djed Contract: 0xCc3664d7021FD36B1Fe2b136e2324710c8442cCf (Verified via on-chain calls)


Stablecoin (ECSD): 0x5A7Ca94F6E969C94bef4CE5e2f90ed9d4891918A (Verified via Blockscout)

<img width="1026" height="902" alt="image" src="https://github.com/user-attachments/assets/ac615c0f-f94e-4c61-9f09-534980778d0d" />
<img width="709" height="918" alt="image" src="https://github.com/user-attachments/assets/4a428bca-9df7-416c-b2bd-d83d77ded58e" />
<img width="685" height="896" alt="image" src="https://github.com/user-attachments/assets/2995153f-4728-49a2-ad54-4f9f01ff0287" />
<img width="532" height="473" alt="image" src="https://github.com/user-attachments/assets/46484a3c-e994-4282-bcd5-4e9afc1bc31f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ethereum Classic mainnet network
  * Native ETC token now available on Mordor testnet and Ethereum Classic mainnet

* **Chores**
  * Renamed Mordor network configuration for clarity
  * Enhanced token configuration with improved transfer settings and decimal specifications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->