### PR TITLE
Migrate DJED SDK from Web3.js to Ethers.js

### DIFF
--- a/stablepay-sdk/package.json
+++ b/stablepay-sdk/package.json
@@ -15,8 +15,7 @@
     "djed-sdk": "^1.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "viem": "^2.21.53",
-    "web3": "^1.7.3"
+    "viem": "^2.21.53"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.25.7",

--- a/stablepay-sdk/rollup.config.mjs
+++ b/stablepay-sdk/rollup.config.mjs
@@ -19,7 +19,6 @@ export default {
       file: "dist/umd/index.js",
       globals: {
         "djed-sdk": "DjedSdk",
-        web3: "Web3",
         react: "React",
         "react-dom": "ReactDOM",
         viem: "viem",
@@ -29,7 +28,7 @@ export default {
       assetFileNames: "assets/[name][extname]",
     },
   ],
-  external: ["djed-sdk", "web3", "react", "react-dom", "viem", "viem/chains"],
+  external: ["djed-sdk", "react", "react-dom", "viem", "viem/chains"],
   plugins: [
     resolve({
       extensions: [".js", ".jsx"],

--- a/stablepay-sdk/src/contexts/WalletContext.jsx
+++ b/stablepay-sdk/src/contexts/WalletContext.jsx
@@ -25,7 +25,7 @@ export const WalletProvider = ({ children }) => {
 
   const connectWallet = useCallback(async () => {
     if (!window.ethereum) {
-      setError('Please install MetaMask or another Web3 wallet');
+      setError('Please install MetaMask or another Ethereum wallet');
       return false;
     }
 

--- a/stablepay-sdk/src/core/Wallet.js
+++ b/stablepay-sdk/src/core/Wallet.js
@@ -7,7 +7,7 @@ export class Wallet {
 
   async connect() {
     if (!window.ethereum) {
-      throw new Error('No Web3 provider found');
+      throw new Error('No Ethereum provider found');
     }
 
     const accounts = await window.ethereum.request({


### PR DESCRIPTION
This PR fully migrates the DJED and StablePay SDKs from Web3.js to Ethers.js v6.

Highlights:
- Replaced Web3 providers with ethers BrowserProvider + signer pattern
- Migrated all contract instantiations to ethers.Contract
- Replaced encodeABI() with interface.encodeFunctionData()
- Updated balance and receipt fetching to ethers provider APIs
- Removed all Web3 dependencies from both SDKs
- Updated documentation and error messages accordingly

Compatibility:
- Public API functions preserved (getWeb3, web3Promise), but getWeb3 now returns
  { provider, signer } instead of a Web3 instance.

Build validation:
- djed-sdk bundles successfully via `npx rollup -c`.
- stablepay-sdk build currently fails on main because required rollup plugins
  (`@rollup/plugin-node-resolve`, `@rollup/plugin-commonjs`) are not listed as dependencies.
  Verified this is a pre-existing packaging issue unrelated to this PR.

Fixes #10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed web3 library dependency from stablepay-sdk, simplifying package dependencies

* **Refactor**
  * Updated wallet provider integration to use provider-signer pattern for contract interactions
  * Modified blockchain details response structure with updated availability indicators

* **Bug Fixes**
  * Clarified error messages when Ethereum provider is not detected

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->