### PR TITLE
Fix: Memoize NetworkContext value to prevent unnecessary re-renders

### DIFF
--- a/stablepay-sdk/src/contexts/NetworkContext.jsx
+++ b/stablepay-sdk/src/contexts/NetworkContext.jsx
@@ -1,4 +1,10 @@
-import React, { createContext, useState, useContext, useEffect } from 'react';
+import React, {
+  createContext,
+  useState,
+  useContext,
+  useEffect,
+  useMemo
+} from 'react';
 import { TokenSelector } from '../core/TokenSelector';
 
 const NetworkContext = createContext();
@@ -17,7 +23,7 @@ export const NetworkProvider = ({ children, networkSelector }) => {
   const selectNetwork = (networkKey) => {
     if (networkSelector.selectNetwork(networkKey)) {
       setSelectedNetwork(networkKey);
-      resetState(); 
+      resetState();
       return true;
     }
     return false;
@@ -43,18 +49,27 @@ export const NetworkProvider = ({ children, networkSelector }) => {
     setSelectedNetwork(networkSelector.selectedNetwork);
   }, [networkSelector.selectedNetwork]);
 
+  // ✅ FIX: Memoize context value to prevent unnecessary re-renders
+  const contextValue = useMemo(() => ({
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails,
+    setTransactionDetails,
+    selectNetwork,
+    selectToken,
+    resetSelections
+  }), [
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails
+  ]);
+
   return (
-    <NetworkContext.Provider value={{ 
-      networkSelector,
-      tokenSelector,
-      selectedNetwork,
-      selectedToken,
-      transactionDetails,
-      setTransactionDetails,
-      selectNetwork,
-      selectToken,
-      resetSelections
-    }}>
+    <NetworkContext.Provider value={contextValue}>
       {children}
     </NetworkContext.Provider>
   );


### PR DESCRIPTION
What
- Memoized the value object passed to NetworkContext.Provider.

Why
- Previously, a new object was created on every render, forcing all consumers to re-render unnecessarily.

How
- Wrapped the provider value in useMemo with appropriate dependencies.

Testing
- Verified the application runs correctly and network related UI flows still work.

Fixes #43


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced network context performance through memory optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->