### PR TITLE
added useMemo to the Memoize NetworkContext.jsx

### DIFF
--- a/stablepay-sdk/src/contexts/NetworkContext.jsx
+++ b/stablepay-sdk/src/contexts/NetworkContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, useEffect } from 'react';
+import React, { createContext, useState, useContext, useEffect, useMemo, useCallback } from 'react';
 import { TokenSelector } from '../core/TokenSelector';
 
 const NetworkContext = createContext();
@@ -9,52 +9,63 @@ export const NetworkProvider = ({ children, networkSelector }) => {
   const [selectedToken, setSelectedToken] = useState(null);
   const [transactionDetails, setTransactionDetails] = useState(null);
 
-  const resetState = () => {
+  const resetState = useCallback(() => {
     setSelectedToken(null);
     setTransactionDetails(null);
-  };
+  }, []);
 
-  const selectNetwork = (networkKey) => {
+  const selectNetwork = useCallback((networkKey) => {
     if (networkSelector.selectNetwork(networkKey)) {
       setSelectedNetwork(networkKey);
       resetState(); 
       return true;
     }
     return false;
-  };
+  }, [networkSelector, resetState]);
 
-  const selectToken = (tokenKey) => {
+  const selectToken = useCallback((tokenKey) => {
     if (tokenSelector.selectToken(tokenKey)) {
       const token = tokenSelector.getSelectedToken();
       setSelectedToken(token);
       return true;
     }
     return false;
-  };
+  }, [tokenSelector]);
 
-  const resetSelections = () => {
+  const resetSelections = useCallback(() => {
     networkSelector.selectNetwork(null);
     setSelectedNetwork(null);
     resetState();
-  };
+  }, [networkSelector, resetState]);
 
   // Synchronize context state with NetworkSelector
   useEffect(() => {
     setSelectedNetwork(networkSelector.selectedNetwork);
   }, [networkSelector.selectedNetwork]);
 
+  const contextValue = useMemo(() => ({ 
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails,
+    setTransactionDetails,
+    selectNetwork,
+    selectToken,
+    resetSelections
+  }), [
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails,
+    selectNetwork,
+    selectToken,
+    resetSelections
+  ]);
+
   return (
-    <NetworkContext.Provider value={{ 
-      networkSelector,
-      tokenSelector,
-      selectedNetwork,
-      selectedToken,
-      transactionDetails,
-      setTransactionDetails,
-      selectNetwork,
-      selectToken,
-      resetSelections
-    }}>
+    <NetworkContext.Provider value={contextValue}>
       {children}
     </NetworkContext.Provider>
   );


### PR DESCRIPTION
Key Effects:

1. **Eliminates Wasted Re-renders: Wrapping the Context value in useMemo ensures that consuming components (like Widget and TransactionReview) only re-render when actual data changes, rather than on every parent render cycle.**

2. **Stabilizes Function References: Implementing useCallback for selectNetwork, selectToken, and resetSelections prevents these functions from being recreated on every render, maintaining stable identities for dependency checks.**

3. **Standardizes Context Pattern: Aligns the context provider with React best practices for high-frequency updates, reducing the overall CPU and memory footprint of the SDK widget.**

###  Wrap context value in useMemo to maintain referential stability
 ```
 const contextValue = useMemo(() => ({ 
    networkSelector,
    tokenSelector,
    selectedNetwork,
    selectedToken,
    transactionDetails,
    setTransactionDetails,
    selectNetwork,
    selectToken,
    resetSelections
  }), [
    networkSelector,
    tokenSelector,
    selectedNetwork,
    selectedToken,
    transactionDetails,
    selectNetwork,
    selectToken,
    resetSelections
  ]);

  return (
    // Pass the memoized object instead of creating a new one {{ ... }}
    <NetworkContext.Provider value={contextValue}>
      {children}
    </NetworkContext.Provider>
  );

```
@Zahnentferner Please checkout this Improvement, If any issue let me know I will fix that . Closes #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added useNetwork() public hook providing simplified access to network context and state management.

* **Refactor**
  * Optimized network context operations to improve performance and application stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->