### PR TITLE
Check chainid before viem client

### DIFF
--- a/stablepay-sdk/src/contexts/NetworkContext.jsx
+++ b/stablepay-sdk/src/contexts/NetworkContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, useEffect } from 'react';
+import React, { createContext, useState, useContext, useEffect, useMemo, useCallback } from 'react';
 import { TokenSelector } from '../core/TokenSelector';
 
 const NetworkContext = createContext();
@@ -9,52 +9,63 @@ export const NetworkProvider = ({ children, networkSelector }) => {
   const [selectedToken, setSelectedToken] = useState(null);
   const [transactionDetails, setTransactionDetails] = useState(null);
 
-  const resetState = () => {
+  const resetState = useCallback(() => {
     setSelectedToken(null);
     setTransactionDetails(null);
-  };
+  }, []);
 
-  const selectNetwork = (networkKey) => {
+  const selectNetwork = useCallback((networkKey) => {
     if (networkSelector.selectNetwork(networkKey)) {
       setSelectedNetwork(networkKey);
       resetState(); 
       return true;
     }
     return false;
-  };
+  }, [networkSelector, resetState]);
 
-  const selectToken = (tokenKey) => {
+  const selectToken = useCallback((tokenKey) => {
     if (tokenSelector.selectToken(tokenKey)) {
       const token = tokenSelector.getSelectedToken();
       setSelectedToken(token);
       return true;
     }
     return false;
-  };
+  }, [tokenSelector]);
 
-  const resetSelections = () => {
+  const resetSelections = useCallback(() => {
     networkSelector.selectNetwork(null);
     setSelectedNetwork(null);
     resetState();
-  };
+  }, [networkSelector, resetState]);
 
   // Synchronize context state with NetworkSelector
   useEffect(() => {
     setSelectedNetwork(networkSelector.selectedNetwork);
   }, [networkSelector.selectedNetwork]);
 
+  const contextValue = useMemo(() => ({ 
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails,
+    setTransactionDetails,
+    selectNetwork,
+    selectToken,
+    resetSelections
+  }), [
+    networkSelector,
+    tokenSelector,
+    selectedNetwork,
+    selectedToken,
+    transactionDetails,
+    selectNetwork,
+    selectToken,
+    resetSelections
+  ]);
+
   return (
-    <NetworkContext.Provider value={{ 
-      networkSelector,
-      tokenSelector,
-      selectedNetwork,
-      selectedToken,
-      transactionDetails,
-      setTransactionDetails,
-      selectNetwork,
-      selectToken,
-      resetSelections
-    }}>
+    <NetworkContext.Provider value={contextValue}>
       {children}
     </NetworkContext.Provider>
   );

--- a/stablepay-sdk/src/contexts/WalletContext.jsx
+++ b/stablepay-sdk/src/contexts/WalletContext.jsx
@@ -218,7 +218,7 @@ export const WalletProvider = ({ children }) => {
     }
 
     try {
-      const chainIdHex = await window.ethereum.request({ method: 'eth_chainId' });
+      const chainIdHex = window.ethereum.chainId || await window.ethereum.request({ method: 'eth_chainId' });
       const currentChainId = parseInt(chainIdHex, 16);
 
       if (currentChainId !== expectedChainId) {


### PR DESCRIPTION
### Sync Check Implemented:

**Old Code: Always used await window.ethereum.request({ method: 'eth_chainId' }), forcing an asynchronous wait even if the data was already available.**

- New Code:` const chainIdHex = window.ethereum.chainId || await ...`

**Benefit: It instantly grabs the chainId from the property if populated (which modern MetaMask versions do), effectively making the check synchronous in most cases and avoiding the network round-trip overhead.**

@Zahnentferner Please review this PR

Closes #46 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized application performance by improving rendering efficiency and wallet connection responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->