### PR TITLE
Handle zero or undefined adaPerUsd in calculation

### DIFF
--- a/djed-sdk/src/helpers.js
+++ b/djed-sdk/src/helpers.js
@@ -104,6 +104,7 @@ export function calculateBcUsdEquivalent(coinsDetails, amountFloat) {
   const adaPerUsd = parseFloat(
     coinsDetails?.scaledScExchangeRate.replaceAll(",", "")
   );
+  if (!adaPerUsd || adaPerUsd === 0) return "0";
   const eqPrice = (1e6 * amountFloat) / adaPerUsd;
   return decimalScaling(eqPrice.toFixed(0).toString(10), 6);
 }


### PR DESCRIPTION
fix this :Division by Zero Vulnerability

Location: djed-sdk/src/helpers.js in calculateBcUsdEquivalent

Issue: const eqPrice = (1e6 * amountFloat) / adaPerUsd;.

Impact: If adaPerUsd (fetched from oracle/contract) is 0 (e.g., during system pause or Oracle failure), this throws Infinity, causing UI crashes.

Fix: Add a check: if (!adaPerUsd || adaPerUsd === 0) return "0";.

@Zahnentferner 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calculation errors by properly handling invalid or zero exchange rate values, preventing computation failures and ensuring data integrity in financial operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->