### PR TITLE
Fix stale price data usage in TransactionReview

### DIFF
--- a/stablepay-sdk/src/widget/TransactionReview.jsx
+++ b/stablepay-sdk/src/widget/TransactionReview.jsx
@@ -86,6 +86,27 @@ const TransactionReview = ({ onTransactionComplete }) => {
     initializeTransaction();
   }, [selectedNetwork, selectedToken, networkSelector, setTransactionDetails]);
 
+  useEffect(() => {
+   
+    if (!transaction || !selectedToken || selectedToken.key !== "native") return;
+
+    const refreshPrice = async () => {
+      try {
+        const tokenAmount = networkSelector.getTokenAmount(selectedToken.key);
+        if (tokenAmount) {
+          const tradeData = await transaction.handleTradeDataBuySc(String(tokenAmount));
+          setTradeDataBuySc(tradeData);
+        }
+      } catch (refreshError) {
+        console.warn("Failed to refresh price data:", refreshError);
+      }
+    };
+
+    const intervalId = setInterval(refreshPrice, 15000); 
+
+    return () => clearInterval(intervalId);
+  }, [transaction, selectedToken, networkSelector]);
+
   if (!contextTransactionDetails) {
     return <div className={styles.loading}>Initializing transaction...</div>;
   }


### PR DESCRIPTION
- implement this fix: Stale Price Data Usage

- Location:` TransactionReview.jsx`

-Issue: **Price data (tradeDataBuySc) is fetched once on component mount. If the user waits 5 minutes before clicking "Pay", the price is outdated.**

- Impact: Transaction failure (if the contract checks limits) or bad execution price for the user.

- Fix: Implement a "Refresh Timer" (e.g., every 15s) or re-fetch quote immediately before signing.

@Zahnentferner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native token trade data now automatically refreshes every 15 seconds during transaction review to provide up-to-date pricing information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->