### PR TITLE
Fix: Remove redundant division in FEE_UI scaling logic

### DIFF
--- a/djed-sdk/src/djed/tradeUtils.js
+++ b/djed-sdk/src/djed/tradeUtils.js
@@ -14,7 +14,7 @@ import {
 
 export const scalingFactor = decimalUnscaling("1", SCALING_DECIMALS);
 export const FEE_UI_UNSCALED = decimalUnscaling(
-  (FEE_UI / 100).toString(),
+  FEE_UI.toString(),
   SCALING_DECIMALS
 );
 export const tradeDataPriceCore = (djed, method, decimals, amountScaled) => {


### PR DESCRIPTION
###  Addressed Issues:
<!-- Link the issue this PR addresses -->
Fixes #66 

Fix: Correct UI fee scaling logic
Problem

FEE_UI_UNSCALED divided FEE_UI by 100 before applying decimalUnscaling.
If FEE_UI already represents a decimal percentage (e.g., 0.01 for 1%), this resulted in a 100× smaller fee being sent to the contract.

Solution

Removed the redundant / 100 and passed FEE_UI directly to decimalUnscaling.

Result

The UI fee is now correctly scaled according to SCALING_DECIMALS.


###  Screenshots/Recordings:
Not applicable.

This change affects internal fee scaling logic in:

djed-sdk/src/djed/tradeUtils.js

No UI components were modified.


###  Additional Notes:
 Problem

FEE_UI_UNSCALED was calculated as:

decimalUnscaling((FEE_UI / 100).toString(), SCALING_DECIMALS)

If FEE_UI already represents a decimal percentage (e.g., 0.01 for 1%), dividing by 100 again reduces the effective fee by 100×.

Example:

FEE_UI = 0.01 (intended 1%)

(FEE_UI / 100) = 0.0001

Resulting contract-side fee = 0.01% instead of 1%

This leads to incorrect fee scaling at the protocol level.


Removed the redundant / 100 and passed FEE_UI directly into decimalUnscaling:

export const FEE_UI_UNSCALED = decimalUnscaling(
  FEE_UI.toString(),
  SCALING_DECIMALS
);
 Result

UI fee is now correctly scaled according to SCALING_DECIMALS

Prevents undercharging by 100×

Aligns SDK behavior with protocol expectations

No breaking API changes

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x ] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [ x] My code follows the project's code style and conventions.
- [ ] If applicable, I have made corresponding changes or additions to the documentation.
- [ ] If applicable, I have made corresponding changes or additions to tests.
- [ x] My changes generate no new warnings or errors.
- [ x] I have joined the Stability Nexus's [Discord server]([https://discord.gg/hjUhu33uAn](https://discord.gg/eqYhuFzuKN)) and I will share a link to this PR with the project maintainers there.
- [ x] I have read the [Contribution Guidelines](../CONTRIBUTING.md).
- [ x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## ⚠️ AI Notice - Important!

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a fee calculation issue in trading that was applying incorrect scaling to transaction fees. Users will now see accurate fee amounts reflected in their trades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->