### PR TITLE
refactor: introduce adapter layer for Djed transaction handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+djed-sdk/.npmrc
+package-lock.json

--- a/djed-sdk/src/adapters/djedAdapter.js
+++ b/djed-sdk/src/adapters/djedAdapter.js
@@ -1,0 +1,15 @@
+import { FEE_UI_UNSCALED } from "../djed/tradeUtils";
+
+export const createDjedAdapter = (djedContract) => {
+  if (!djedContract || !djedContract.methods) {
+    throw new Error("Djed contract instance is required");
+  }
+
+  return {
+    buyStableCoins: (receiver, UI) =>
+      djedContract.methods.buyStableCoins(receiver, FEE_UI_UNSCALED, UI),
+
+    sellStableCoins: (amount, account, UI) =>
+      djedContract.methods.sellStableCoins(amount, account, FEE_UI_UNSCALED, UI),
+  };
+};

--- a/djed-sdk/src/adapters/djedAdapter.js
+++ b/djed-sdk/src/adapters/djedAdapter.js
@@ -24,10 +24,10 @@ export const createDjedAdapter = (djedContract) => {
   }
 
   return {
-    buyStableCoins: (receiver, UI) =>
-      methods.buyStableCoins(receiver, FEE_UI_UNSCALED, UI),
+    buyStableCoins: (receiver, ui) =>
+      methods.buyStableCoins(receiver, FEE_UI_UNSCALED, ui),
 
-    sellStableCoins: (amount, account, UI) =>
-      methods.sellStableCoins(amount, account, FEE_UI_UNSCALED, UI),
+    sellStableCoins: (amount, account, ui) =>
+      methods.sellStableCoins(amount, account, FEE_UI_UNSCALED, ui),
   };
 };

--- a/djed-sdk/src/adapters/djedAdapter.js
+++ b/djed-sdk/src/adapters/djedAdapter.js
@@ -1,15 +1,24 @@
 import { FEE_UI_UNSCALED } from "../djed/tradeUtils";
 
 export const createDjedAdapter = (djedContract) => {
-  if (!djedContract || !djedContract.methods) {
-    throw new Error("Djed contract instance is required");
+  const methods = djedContract?.methods;
+
+  // Fail fast if required methods are missing
+  if (
+    !methods ||
+    typeof methods.buyStableCoins !== "function" ||
+    typeof methods.sellStableCoins !== "function"
+  ) {
+    throw new Error(
+      "Invalid Djed contract instance: missing required methods (buyStableCoins, sellStableCoins)"
+    );
   }
 
   return {
     buyStableCoins: (receiver, UI) =>
-      djedContract.methods.buyStableCoins(receiver, FEE_UI_UNSCALED, UI),
+      methods.buyStableCoins(receiver, FEE_UI_UNSCALED, UI),
 
     sellStableCoins: (amount, account, UI) =>
-      djedContract.methods.sellStableCoins(amount, account, FEE_UI_UNSCALED, UI),
+      methods.sellStableCoins(amount, account, FEE_UI_UNSCALED, UI),
   };
 };

--- a/djed-sdk/src/adapters/djedAdapter.js
+++ b/djed-sdk/src/adapters/djedAdapter.js
@@ -3,14 +3,23 @@ import { FEE_UI_UNSCALED } from "../djed/tradeUtils";
 export const createDjedAdapter = (djedContract) => {
   const methods = djedContract?.methods;
 
-  // Fail fast if required methods are missing
-  if (
-    !methods ||
-    typeof methods.buyStableCoins !== "function" ||
-    typeof methods.sellStableCoins !== "function"
-  ) {
+  const missingMethods = [];
+
+  if (!methods) {
+    throw new Error("Invalid Djed contract instance: methods object is missing");
+  }
+
+  if (typeof methods.buyStableCoins !== "function") {
+    missingMethods.push("buyStableCoins");
+  }
+
+  if (typeof methods.sellStableCoins !== "function") {
+    missingMethods.push("sellStableCoins");
+  }
+
+  if (missingMethods.length > 0) {
     throw new Error(
-      "Invalid Djed contract instance: missing required methods (buyStableCoins, sellStableCoins)"
+      `Djed contract is missing required methods: ${missingMethods.join(", ")}`
     );
   }
 

--- a/djed-sdk/src/djed/djed.js
+++ b/djed-sdk/src/djed/djed.js
@@ -29,14 +29,13 @@ export const getDecimals = async (stableCoin, reserveCoin) => {
   return { scDecimals, rcDecimals };
 };
 
-const buyScTx = (djed, payer, receiver, value, UI, DJED_ADDRESS) => {
-  const adapter = createDjedAdapter(djed);
-  const data = adapter.buyStableCoins(receiver, UI).encodeABI();
+// Adapter should be created once and passed in (dependency injection)
+const buyScTx = (adapter, payer, receiver, value, ui, DJED_ADDRESS) => {
+  const data = adapter.buyStableCoins(receiver, ui).encodeABI();
   return buildTx(payer, DJED_ADDRESS, value, data);
 };
 
-const sellScTx = (djed, account, amount, UI, DJED_ADDRESS) => {
-  const adapter = createDjedAdapter(djed);
-  const data = adapter.sellStableCoins(amount, account, UI).encodeABI();
+const sellScTx = (adapter, account, amount, ui, DJED_ADDRESS) => {
+  const data = adapter.sellStableCoins(amount, account, ui).encodeABI();
   return buildTx(account, DJED_ADDRESS, 0, data);
 };

--- a/djed-sdk/src/djed/djed.js
+++ b/djed-sdk/src/djed/djed.js
@@ -1,6 +1,7 @@
 import djedArtifact from "../artifacts/DjedABI.json";
 import coinArtifact from "../artifacts/CoinABI.json";
-import { convertInt, web3Promise } from "../helpers";
+import { convertInt, web3Promise, buildTx } from "../helpers";
+import { createDjedAdapter } from "../adapters/djedAdapter";
 
 //setting up djed
 export const getDjedContract = (web3, DJED_ADDRESS) => {
@@ -26,4 +27,16 @@ export const getDecimals = async (stableCoin, reserveCoin) => {
     convertInt(web3Promise(reserveCoin, "decimals")),
   ]);
   return { scDecimals, rcDecimals };
+};
+
+const buyScTx = (djed, payer, receiver, value, UI, DJED_ADDRESS) => {
+  const adapter = createDjedAdapter(djed);
+  const data = adapter.buyStableCoins(receiver, UI).encodeABI();
+  return buildTx(payer, DJED_ADDRESS, value, data);
+};
+
+const sellScTx = (djed, account, amount, UI, DJED_ADDRESS) => {
+  const adapter = createDjedAdapter(djed);
+  const data = adapter.sellStableCoins(amount, account, UI).encodeABI();
+  return buildTx(account, DJED_ADDRESS, 0, data);
 };


### PR DESCRIPTION
### Summary

This PR refactors Djed contract interaction by introducing an adapter layer to centralize transaction-building logic.

Previously, transaction methods like `buyStableCoins` and `sellStableCoins` were called directly from multiple locations. This change introduces a `createDjedAdapter` abstraction that standardizes how these interactions are handled.

### Changes Made

* Added `djed-sdk/src/adapters/djedAdapter.js`
* Implemented `createDjedAdapter(djedContract)`:

  * Wraps contract methods
  * Injects `FEE_UI_UNSCALED` internally
* Refactored:

  * `buyScTx`
  * `sellScTx`
* Removed direct dependency on contract method calls in transaction builders

### Why this change?

* Improves separation of concerns
* Makes the codebase more modular and maintainable
* Enables easier support for multiple Djed variants (Osiris, Shu, Tefnut, etc.)
* Avoids duplication of fee-related logic across the codebase

### Impact

* No change in external behavior
* Internal structure is cleaner and more extensible

### Notes

* This is a foundational refactor for future protocol adapter support
* Happy to extend this pattern to other contract interactions if needed

### Checklist

* [x] Code follows project conventions
* [x] Refactor does not break existing functionality
* [x] Focused, single-purpose PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced an adapter layer to standardize stablecoin buy/sell interactions and ensure required methods exist.
  * Added internal transaction helpers to prepare and build buy/sell stablecoin transactions with consistent fee handling.
  * Improved validation and clearer error handling for the contract interface to reduce runtime failures.

* **Chores**
  * Updated ignore rules to exclude local/npm metadata files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->